### PR TITLE
Add functionality for rendering AABox, Circle, and OBox logic shape types and fix crash when changing logic shape type

### DIFF
--- a/dread_editor/level_data.py
+++ b/dread_editor/level_data.py
@@ -290,18 +290,21 @@ class LevelData:
                             and actor.pComponents.LOGICSHAPE["@type"] == 'CLogicShapeComponent'):
                         shape = actor.pComponents.LOGICSHAPE.pLogicShape
                         if shape is not None and shape["@type"] == 'game::logic::collision::CPolygonCollectionShape':
-                            for poly in shape.oPolyCollection.vPolys:
-                                vertices = []
-                                for p in poly.oSegmentData:
-                                    vertices.append(
-                                        (lerp_x(p.vPos[0] + actor.vPos[0]),
-                                         lerp_y(p.vPos[1] + actor.vPos[1]))
+                            try:
+                                for poly in shape.oPolyCollection.vPolys:
+                                    vertices = []
+                                    for p in poly.oSegmentData:
+                                        vertices.append(
+                                            (lerp_x(p.vPos[0] + actor.vPos[0]),
+                                            lerp_y(p.vPos[1] + actor.vPos[1]))
+                                        )
+                                    draw_list.add_polyline(
+                                        vertices, color,
+                                        closed=poly.bClosed,
+                                        thickness=3,
                                     )
-                                draw_list.add_polyline(
-                                    vertices, color,
-                                    closed=poly.bClosed,
-                                    thickness=3,
-                                )
+                            except AttributeError:
+                                pass
 
             if self.highlighted_actors_in_canvas and imgui.is_window_hovered():
                 imgui.begin_tooltip()

--- a/dread_editor/level_data.py
+++ b/dread_editor/level_data.py
@@ -1,6 +1,7 @@
 import colorsys
 import copy
 import hashlib
+import math
 import os
 import struct
 import typing
@@ -289,7 +290,54 @@ class LevelData:
                     if ("LOGICSHAPE" in actor.pComponents
                             and actor.pComponents.LOGICSHAPE["@type"] == 'CLogicShapeComponent'):
                         shape = actor.pComponents.LOGICSHAPE.pLogicShape
-                        if shape is not None and shape["@type"] == 'game::logic::collision::CPolygonCollectionShape':
+
+                        
+                        if shape is not None and shape["@type"] == 'game::logic::collision::CAABoxShape2D':
+                            try:
+                                draw_list.add_rect(
+                                        lerp_x(shape.v2Min[0] + actor.vPos[0]),
+                                        lerp_y(shape.v2Min[1] + actor.vPos[1]),
+                                        lerp_x(shape.v2Max[0] + actor.vPos[0]),
+                                        lerp_y(shape.v2Max[1] + actor.vPos[1]),
+                                        color,
+                                        thickness=3,
+                                    )
+                            except AttributeError:
+                                pass
+                        elif shape is not None and shape["@type"] == 'game::logic::collision::CCircleShape2D':
+                            try:
+                                draw_list.add_circle(
+                                        lerp_x(actor.vPos[0]),
+                                        lerp_y(actor.vPos[1]),
+                                        shape.fRadius,
+                                        color,
+                                        num_segments=32,
+                                        thickness=3,
+                                    )
+                            except AttributeError:
+                                pass
+                        elif shape is not None and shape["@type"] == 'game::logic::collision::COBoxShape2D':
+                            try:
+                                angleSin = math.sin(shape.fDegrees)
+                                angleCos = math.cos(shape.fDegrees)
+                                draw_list.add_polyline(
+                                        [
+                                            (lerp_x((shape.v2Extent[0] * -1 * angleCos) - (shape.v2Extent[1] * angleSin) + actor.vPos[0]),
+                                            lerp_y((shape.v2Extent[0] * -1 * angleSin) + (shape.v2Extent[1] * angleCos) + actor.vPos[1])),
+                                            (lerp_x((shape.v2Extent[0] * angleCos) - (shape.v2Extent[1] * angleSin) + actor.vPos[0]),
+                                            lerp_y((shape.v2Extent[0] * angleSin) + (shape.v2Extent[1] * angleCos) + actor.vPos[1])),
+                                            (lerp_x((shape.v2Extent[0] * angleCos) - (shape.v2Extent[1] * -1 * angleSin) + actor.vPos[0]),
+                                            lerp_y((shape.v2Extent[0] * angleSin) + (shape.v2Extent[1] * -1 * angleCos) + actor.vPos[1])),
+                                            (lerp_x((shape.v2Extent[0] * -1 * angleCos) - (shape.v2Extent[1] * -1 * angleSin) + actor.vPos[0]),
+                                            lerp_y((shape.v2Extent[0] * -1 * angleSin) + (shape.v2Extent[1] * -1 * angleCos) + actor.vPos[1]))
+                                        ],
+                                        color,
+                                        closed=poly.bClosed,
+                                        thickness=3,
+                                    )
+                            except AttributeError:
+                                pass
+                        elif shape is not None and shape["@type"] == 'game::logic::collision::CPolygonCollectionShape':
                             try:
                                 for poly in shape.oPolyCollection.vPolys:
                                     vertices = []


### PR DESCRIPTION
Capsule logic shapes still are not rendered, as there isn't enough information to know what orientation they would be in.